### PR TITLE
Fix nullable defaultValue

### DIFF
--- a/FlagShip/Source/Core/FSFlag.swift
+++ b/FlagShip/Source/Core/FSFlag.swift
@@ -88,6 +88,10 @@ public class FSFlag: NSObject {
     /// _ Check the type of flag's value with the default value
     private func isSameType<T>(_ value: T)->Bool {
         var matchedType = false
+
+        if defaultValue == nil {
+            return true
+        }
         
         switch defaultValue {
         case _ as String:


### PR DESCRIPTION
When we initing the FSFlag we lose the Generics type in the case where it is `nil` because it is cast to `Any?`

![image](https://github.com/flagship-io/flagship-ios/assets/35778025/22b0d9a6-f2c5-45b5-b0b8-5e8ef52d9d65)

So the FSFlag.value() always return nil because the function `isSameType<T>(_ value: T)` always return false (line 25 FSLag.swift)
![image](https://github.com/flagship-io/flagship-ios/assets/35778025/5d8c7e14-16be-4fa6-9f93-ab1d11ee8704)

What I suggest to solve the problem is that in case the defaultValue is nil isSameType returns true

Here is the function I use in my application to retrieve a flag: 

![image](https://github.com/flagship-io/flagship-ios/assets/35778025/7329d71f-2808-4126-a88f-df0005b77030)