### PR TITLE
Access race fix

### DIFF
--- a/FlagShip/Source/API/FSService+Bucketing.swift
+++ b/FlagShip/Source/API/FSService+Bucketing.swift
@@ -26,45 +26,47 @@ extension FSService {
 
             serviceSession.dataTask(with: request) { data, response, _ in
 
-                let httpResponse = response as? HTTPURLResponse
+                DispatchQueue.main.async {
+                    let httpResponse = response as? HTTPURLResponse
 
-                switch httpResponse?.statusCode {
-                case 200:
-                    /// Manage last modified
-                    self.manageLastModified(httpResponse)
+                    switch httpResponse?.statusCode {
+                    case 200:
+                        /// Manage last modified
+                        self.manageLastModified(httpResponse)
 
-                    if let responseData = data {
-                        do {
-                            /// Display Json response
-                            FlagshipLogManager.Log(level: .ALL, tag: .BUCKETING, messageToDisplay: FSLogMessage.GET_SCRIPT_RESPONSE("\(responseData.prettyPrintedJSONString ?? "Error on display jsonString")"))
+                        if let responseData = data {
+                            do {
+                                /// Display Json response
+                                FlagshipLogManager.Log(level: .ALL, tag: .BUCKETING, messageToDisplay: FSLogMessage.GET_SCRIPT_RESPONSE("\(responseData.prettyPrintedJSONString ?? "Error on display jsonString")"))
 
-                            let scriptObject = try JSONDecoder().decode(FSBucket.self, from: responseData)
-                            onGetScript(scriptObject, nil)
+                                let scriptObject = try JSONDecoder().decode(FSBucket.self, from: responseData)
+                                onGetScript(scriptObject, nil)
 
-                            /// Save bucket script
-                            FSStorageManager.saveBucketScriptInCache(data)
+                                /// Save bucket script
+                                FSStorageManager.saveBucketScriptInCache(data)
 
-                            // TR the bucketing file
-                            FSDataUsageTracking.sharedInstance.processTSBucketingFile(httpResponse, request, responseData)
+                                // TR the bucketing file
+                                FSDataUsageTracking.sharedInstance.processTSBucketingFile(httpResponse, request, responseData)
 
-                        } catch {
-                            FlagshipLogManager.Log(level: .ERROR, tag: .BUCKETING, messageToDisplay: FSLogMessage.ERROR_ON_DECODE_JSON)
-                            onGetScript(nil, FlagshipError(type: .internalError, code: 400))
+                            } catch {
+                                FlagshipLogManager.Log(level: .ERROR, tag: .BUCKETING, messageToDisplay: FSLogMessage.ERROR_ON_DECODE_JSON)
+                                onGetScript(nil, FlagshipError(type: .internalError, code: 400))
+                            }
                         }
+
+                    case 304:
+                        /// Read the script from the cache
+                        FlagshipLogManager.Log(level: .ALL, tag: .BUCKETING, messageToDisplay: FSLogMessage.BUCKETING_CODE_304)
+                        onGetScript(nil, FlagshipError(type: .notModified, code: 304))
+
+                    default:
+                        FlagshipLogManager.Log(level: .ALL, tag: .BUCKETING, messageToDisplay: FSLogMessage.ERROR_ON_GET_SCRIPT)
+                        onGetScript(nil, FlagshipError(type: .internalError, code: 400))
+
+                        // TS for bucketing error
+                        FSDataUsageTracking.sharedInstance.processTSHttp(crticalPointLabel: .SDK_BUCKETING_FILE_ERROR,
+                                                                         httpResponse, request, nil)
                     }
-
-                case 304:
-                    /// Read the script from the cache
-                    FlagshipLogManager.Log(level: .ALL, tag: .BUCKETING, messageToDisplay: FSLogMessage.BUCKETING_CODE_304)
-                    onGetScript(nil, FlagshipError(type: .notModified, code: 304))
-
-                default:
-                    FlagshipLogManager.Log(level: .ALL, tag: .BUCKETING, messageToDisplay: FSLogMessage.ERROR_ON_GET_SCRIPT)
-                    onGetScript(nil, FlagshipError(type: .internalError, code: 400))
-
-                    // TS for bucketing error
-                    FSDataUsageTracking.sharedInstance.processTSHttp(crticalPointLabel: .SDK_BUCKETING_FILE_ERROR,
-                                                                     httpResponse, request, nil)
                 }
             }.resume()
         }

--- a/FlagShip/Source/API/FSService+Request.swift
+++ b/FlagShip/Source/API/FSService+Request.swift
@@ -36,22 +36,23 @@ extension FSService {
         }
         
         serviceSession.dataTask(with: request) { data, response, error in
-            
-            if error != nil {
-                onCompleted(nil, error)
-                
-                FSDataUsageTracking.sharedInstance.processTSHttpError(requestType: type, response as? HTTPURLResponse, request, data)
-            } else {
-                if let httpResponse = response as? HTTPURLResponse {
-                    if (200 ... 299).contains(httpResponse.statusCode) {
-                        onCompleted(data, nil)
-                        
-                    } else {
-                        FSDataUsageTracking.sharedInstance.processTSHttpError(requestType: type, response as? HTTPURLResponse, request, data)
-                        onCompleted(nil, FlagshipError(type: .sendRequest, code: httpResponse.statusCode))
-                    }
+            DispatchQueue.main.async {
+                if error != nil {
+                    onCompleted(nil, error)
+
+                    FSDataUsageTracking.sharedInstance.processTSHttpError(requestType: type, response as? HTTPURLResponse, request, data)
                 } else {
-                    onCompleted(nil, FlagshipError(type: .sendRequest, code: 400))
+                    if let httpResponse = response as? HTTPURLResponse {
+                        if (200 ... 299).contains(httpResponse.statusCode) {
+                            onCompleted(data, nil)
+
+                        } else {
+                            FSDataUsageTracking.sharedInstance.processTSHttpError(requestType: type, response as? HTTPURLResponse, request, data)
+                            onCompleted(nil, FlagshipError(type: .sendRequest, code: httpResponse.statusCode))
+                        }
+                    } else {
+                        onCompleted(nil, FlagshipError(type: .sendRequest, code: 400))
+                    }
                 }
             }
         }.resume()

--- a/FlagShip/Source/Decision/Bucketing/FSPollingScript.swift
+++ b/FlagShip/Source/Decision/Bucketing/FSPollingScript.swift
@@ -90,7 +90,9 @@ class FSRepeatingTimer {
         let t = DispatchSource.makeTimerSource()
         t.schedule(deadline: .now(), repeating: self.timeInterval)
         t.setEventHandler(handler: { [weak self] in
-            self?.eventHandler?()
+            DispatchQueue.main.async {
+                self?.eventHandler?()
+            }
         })
         return t
     }()


### PR DESCRIPTION
There are a few places causing access races in `flagship-ios`. The reasons for this are listed below

- `DispatchSourceTimer` has its own arbitrary queue, therefore calling the event handler without dispatching to the main queue introduces a race
- `URLSession.dataTask` always uses a non-main internal queue, therefore you are required to switch back to the main queue before calling any completion handlers, or code which introduces side effects. The only time you dont need to do this if you know the code called has been made thread-safe with whatever locking mechanism you prefer.

This can be tested with the current `master` branch, and 
[this patch](https://github.com/flagship-io/flagship-ios/files/14523928/flagship.patch). After applying this patch, build and run and you should see a thread sanitiser warning. Given its an access race, it may take you a couple of runs to get the warning to show.

After checking out this branch, you should no longer see these warnings.
